### PR TITLE
installation of openjdk11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.0 Unreleased]
+
+### Added
+
+- Java(openjdk 11.0.8)
+
 ## [0.2.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 .DEFAULT_GOAL := build
 
 build:
-	(cd packer; rm -rf output-hashistack; packer build -force .)
+	(cd packer; rm -rf output-bionic64; packer build -force .)
 
 test:
 ifeq (,$(wildcard ./packer/output-bionic64/package.box))
-	#$(MAKE) build
+	$(MAKE) build
 endif
 	vagrant up
 

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Available on [vagrant cloud](https://app.vagrantup.com/fredrikhgrelland/boxes/bi
 - Ansible
 - minio
 - minio client (mc)
+- java

--- a/packer/cleanup.sh
+++ b/packer/cleanup.sh
@@ -34,7 +34,7 @@ dpkg --list \
     | xargs apt-get -y purge;
 
 # Delete X11 libraries
-apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6;
+apt-get -y purge xauth;
 
 # Delete obsolete networking
 apt-get -y purge ppp pppconfig pppoeconf;

--- a/packer/install.sh
+++ b/packer/install.sh
@@ -6,3 +6,8 @@ apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get upgrade --no-install-recommends -q -y -u -o Dpkg::Options::="--force-confdef" --allow-downgrades --allow-remove-essential --allow-change-held-packages --allow-change-held-packages --allow-unauthenticated;
 apt-get install --no-install-recommends -y python3-distutils jq unzip && curl -k -s https://bootstrap.pypa.io/get-pip.py | sudo -H python3
 pip install 'ansible==2.9.11'
+
+#install java and set JAVA_HOME
+sudo apt-get install -y openjdk-11-jre openjdk-11-jdk
+echo "JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/" >> /etc/environment
+source /etc/environment


### PR DESCRIPTION
closes #3 
I have created a draft PR as i see that the openjdk gets deleted by the cleanup.sh script when the following line of code is executed:
`vagrant.bionic64: + apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6
`
**Note**: I have removed this command from cleanup.sh file.
```
==> vagrant.bionic64: + apt-get -y purge libx11-data xauth libxmuu1 libxcb1 libx11-6 libxext6
    vagrant.bionic64: Reading package lists...
    vagrant.bionic64: Building dependency tree...
    vagrant.bionic64: Reading state information...
    vagrant.bionic64: Package 'xauth' is not installed, so not removed
    vagrant.bionic64: The following packages were automatically installed and are no longer required:
    vagrant.bionic64:   fontconfig-config fonts-dejavu-core fonts-dejavu-extra java-common
    vagrant.bionic64:   libasound2 libasound2-data libatk1.0-0 libatk1.0-data libdrm-amdgpu1
    vagrant.bionic64:   libdrm-intel1 libdrm-nouveau2 libdrm-radeon1 libfontconfig1 libfontenc1
    vagrant.bionic64:   libgif7 libgl1-mesa-dri libglapi-mesa libglvnd0 libice6 libjpeg-turbo8
    vagrant.bionic64:   libjpeg8 liblcms2-2 libllvm10 libnspr4 libnss3 libpciaccess0 libpcsclite1
    vagrant.bionic64:   libpthread-stubs0-dev libsensors4 libsm6 libx11-xcb1 libxshmfence1
    vagrant.bionic64:   x11-common xorg-sgml-doctools
    vagrant.bionic64: Use 'sudo apt autoremove' to remove them.
    vagrant.bionic64: The following packages will be REMOVED:
    vagrant.bionic64:   at-spi2-core* ca-certificates-java* libatk-bridge2.0-0* libatk-wrapper-java*
    vagrant.bionic64:   libatk-wrapper-java-jni* libatspi2.0-0* libgl1* libglx-mesa0* libglx0*
    vagrant.bionic64:   libx11-6* libx11-data* libxaw7* libxcb-dri2-0* libxcb-dri3-0* libxcb-glx0*
    vagrant.bionic64:   libxcb-present0* libxcb-shape0* libxcb-sync1* libxcb1* libxcomposite1*
    vagrant.bionic64:   libxdamage1* libxext6* libxfixes3* libxft2* libxi6* libxinerama1* libxmu6*
    vagrant.bionic64:   libxmuu1* libxpm4* libxrandr2* libxrender1* libxt6* libxtst6* libxv1*
    vagrant.bionic64:   libxxf86dga1* libxxf86vm1* openjdk-11-jdk* openjdk-11-jdk-headless*
    vagrant.bionic64:   openjdk-11-jre* openjdk-11-jre-headless* x11-utils*
    vagrant.bionic64: 0 upgraded, 0 newly installed, 41 to remove and 4 not upgraded.
    vagrant.bionic64: After this operation, 384 MB disk space will be freed.
    vagrant.bionic64: (Reading database ... 45073 files and directories currently installed.)
    vagrant.bionic64: Removing at-spi2-core (2.28.0-1) ...
    vagrant.bionic64: Removing openjdk-11-jdk:amd64 (11.0.8+10-0ubuntu1~18.04.1) ...
    vagrant.bionic64: Removing openjdk-11-jre:amd64 (11.0.8+10-0ubuntu1~18.04.1) ...
    vagrant.bionic64: Removing openjdk-11-jdk-headless:amd64 (11.0.8+10-0ubuntu1~18.04.1) ...
    vagrant.bionic64: Removing libatk-wrapper-java-jni:amd64 (0.33.3-20ubuntu0.1) ...
    vagrant.bionic64: Removing libatk-bridge2.0-0:amd64 (2.26.2-1) ...
    vagrant.bionic64: Removing libatk-wrapper-java (0.33.3-20ubuntu0.1) ...
    vagrant.bionic64: Removing libatspi2.0-0:amd64 (2.28.0-1) ...
    vagrant.bionic64: Removing x11-utils (7.7+3build1) ...

```